### PR TITLE
chore: bump version to 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "claude-explorer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "claude-explorer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["jsleemaster"]
 description = "A TUI file explorer for Claude Code CLI"


### PR DESCRIPTION
## Summary

- Bump version from 0.1.0 to 0.2.0 to match release tag v0.2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)