### PR TITLE
docs: update docs and add code of conduct for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-02-10
+
+### Removed
+
+- Focus switching between panes (Tab key)
+- Interactive file tree navigation (j/k/g/G/h/l keys)
+- File search functionality (/)
+- Help popup (? / F1)
+- @path insertion on Enter
+- Directory cd on Enter
+
+### Added
+
+- CWD marker (●) showing Claude Code's current working directory in the file tree
+- OSC 7 escape sequence support for CWD detection
+- vterm buffer scanning as fallback CWD detection
+- Debounced tree refresh on CWD changes
+- Enhanced key handling — all keystrokes forwarded to terminal
+
+### Changed
+
+- File tree is now always fully expanded (read-only passive display)
+- All key input is passed directly to Claude Code terminal
+- Event loop rewritten with tokio select! for improved responsiveness
+
 ## [0.1.0] - 2025-02-05
 
 ### Added
@@ -26,5 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Command line options for path, tree width, hidden files, and depth
 - Help popup with `?` or `F1`
 
-[Unreleased]: https://github.com/jsleemaster/claude-explorer/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/jsleemaster/claude-explorer/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/jsleemaster/claude-explorer/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/jsleemaster/claude-explorer/releases/tag/v0.1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[GitHub Issues](https://github.com/jsleemaster/claude-explorer/issues).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -22,20 +22,19 @@ A terminal-based file explorer designed to work alongside Claude Code CLI. View 
 │                                             │ ├── 📖 README.md     │
 │                                             │ └── 📄 .gitignore    │
 │                                             │                      │
-│                                             │ Tab: switch | ?: help│
+│                                             │ ● src/ui             │
 └─────────────────────────────────────────────┴──────────────────────┘
 ```
 
 ## ✨ Features
 
 - **Split-pane TUI**: File tree on the right, Claude Code on the left
-- **Interactive file tree**: Navigate, expand/collapse directories
-- **Quick file reference**: Press Enter on a file to insert `@path` in Claude Code
-- **Directory navigation**: Press Enter on a directory to `cd` into it
-- **Search**: Find files by name with `/` search
+- **Passive file tree**: Always-expanded, read-only project structure display
+- **CWD tracking**: Highlights Claude Code's current working directory with a ● marker
+- **OSC 7 + vterm detection**: Automatically detects directory changes via escape sequences
 - **gitignore support**: Respects `.gitignore` patterns
 - **File icons**: Visual indicators for different file types
-- **Keyboard-driven**: Vim-style navigation
+- **Zero interference**: All keystrokes are forwarded directly to Claude Code
 
 ## 📦 Installation
 
@@ -85,31 +84,11 @@ claude-explorer --show-hidden
 
 ## ⌨️ Keyboard Shortcuts
 
-### Global
 | Key | Action |
 |-----|--------|
-| `Tab` | Switch between Tree and Terminal panes |
-| `Ctrl+T` | Focus Tree pane |
 | `Ctrl+Q` | Quit |
-| `F1` / `?` | Toggle help |
 
-### File Tree Pane
-| Key | Action |
-|-----|--------|
-| `j` / `↓` | Move down |
-| `k` / `↑` | Move up |
-| `g` / `Home` | Go to first |
-| `G` / `End` | Go to last |
-| `Enter` / `l` | Open/expand or insert path |
-| `h` / `←` | Collapse or go to parent |
-| `Space` | Toggle expand/collapse |
-| `/` | Start search |
-| `n` / `N` | Next/previous search result |
-| `.` | Toggle hidden files |
-| `r` / `F5` | Refresh tree |
-
-### Terminal Pane
-All keys are passed directly to Claude Code.
+All other keystrokes are passed directly to Claude Code.
 
 ## 🔧 Configuration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,8 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.1.x   | :white_check_mark: |
+| 0.2.x   | :white_check_mark: |
+| 0.1.x   | :x:                |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

- Add v0.2.0 section to CHANGELOG.md (removed interactive features, added CWD tracking)
- Update README.md to reflect passive file tree display model
- Update SECURITY.md supported versions (0.2.x supported, 0.1.x EOL)
- Add CODE_OF_CONDUCT.md (Contributor Covenant v2.1)

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 54 tests pass
- [ ] Verify rendered markdown on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)