### PR TITLE
docs: sync CLAUDE.md with v0.2.0 and gitignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ Thumbs.db
 .env
 .env.local
 
+# Claude Code
+.claude/
+
 # npm package - downloaded binaries
 npm/bin/claude-explorer
 npm/bin/claude-explorer.exe

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,17 +8,18 @@ Claude Code CLI 옆에 파일 트리를 보여주는 TUI 앱. Rust + ratatui 기
 claude-explorer/
 ├── src/
 │   ├── main.rs              # 진입점, 터미널 초기화, 이벤트 루프
-│   ├── app.rs               # App 상태, 키 입력 핸들링, 포커스 관리
+│   ├── app.rs               # App 상태, 키 입력 핸들링
 │   ├── event.rs             # 비동기 이벤트 핸들러 (키, 마우스, 리사이즈)
+│   ├── lib.rs               # 라이브러리 모듈 선언
 │   ├── terminal.rs          # PTY 관리, Claude Code 프로세스 실행
+│   ├── vterm.rs             # 가상 터미널 버퍼 (ANSI 파싱, 셀 기반 렌더링)
 │   ├── tree/
-│   │   ├── mod.rs           # FileTree 구조체, 트리 빌드/탐색 로직
+│   │   ├── mod.rs           # FileTree 구조체, 트리 빌드 로직
 │   │   └── file_node.rs     # FileNode 구조체, 파일 아이콘 매핑
 │   └── ui/
 │       ├── mod.rs           # draw() 함수, 레이아웃 분할
 │       ├── file_tree_widget.rs   # 트리 렌더링 위젯
-│       ├── terminal_widget.rs    # ANSI 파싱, 터미널 출력 위젯
-│       └── help_popup.rs         # 도움말 팝업
+│       └── terminal_widget.rs    # vterm 버퍼 → ratatui 위젯 변환
 ├── Cargo.toml
 ├── README.md
 ├── LICENSE                  # MIT
@@ -27,11 +28,11 @@ claude-explorer/
 
 ## 핵심 의존성
 
-- `ratatui` (0.29): TUI 프레임워크
-- `crossterm` (0.28): 크로스플랫폼 터미널 제어
-- `portable-pty` (0.8): PTY 생성 및 프로세스 관리
+- `ratatui` (0.30): TUI 프레임워크
+- `crossterm` (0.29): 크로스플랫폼 터미널 제어
+- `portable-pty` (0.9): PTY 생성 및 프로세스 관리
 - `tokio` (1.42): 비동기 런타임
-- `notify` (7.0): 파일시스템 감시
+- `notify` (8.2) + `notify-debouncer-mini` (0.7): 파일시스템 감시
 - `ignore` (0.4): gitignore 지원 파일 워킹
 - `clap` (4.5): CLI 인자 파싱
 
@@ -54,17 +55,17 @@ claude-explorer/
 │ - App struct  │    │ - Event enum  │    │ - draw()      │
 │ - FileTree    │◄───│ - Tick        │    │ - Layout      │
 │ - TerminalPane│    │ - Key/Mouse   │    │               │
-│ - 상태 관리   │    │ - Resize      │    │               │
+│ - CWD 추적    │    │ - Resize      │    │               │
 └───────────────┘    └───────────────┘    └───────────────┘
         │                                         │
         ▼                                         ▼
-┌───────────────┐                        ┌───────────────┐
-│  terminal.rs  │                        │   widgets     │
-│               │                        │               │
-│ - PTY 생성    │                        │ - TreeWidget  │
-│ - Claude 실행 │                        │ - TermWidget  │
-│ - I/O 처리    │                        │ - HelpPopup   │
-└───────────────┘                        └───────────────┘
+┌───────────────┐    ┌───────────────┐   ┌───────────────┐
+│  terminal.rs  │    │   vterm.rs    │   │   widgets     │
+│               │    │               │   │               │
+│ - PTY 생성    │    │ - 셀 버퍼    │   │ - TreeWidget  │
+│ - Claude 실행 │───▶│ - ANSI 파싱  │   │ - TermWidget  │
+│ - I/O 처리    │    │ - CWD 감지   │   │               │
+└───────────────┘    └───────────────┘   └───────────────┘
 ```
 
 ## 빌드 & 실행
@@ -105,21 +106,24 @@ cargo fmt
 - 백그라운드 스레드에서 출력 읽기 (non-blocking)
 - 키 입력을 PTY master로 전송
 
-### 2. ANSI 파싱 (terminal_widget.rs)
+### 2. 가상 터미널 (vterm.rs)
+- 셀 기반 터미널 버퍼 (행/열 그리드)
 - SGR 이스케이프 시퀀스 파싱 (색상, 볼드 등)
-- ratatui Style로 변환
-- 제어 문자 처리 (탭, 캐리지 리턴 등)
+- 커서 이동, 삽입/삭제, 스크롤 처리
+- OSC 7 이스케이프 시퀀스로 CWD 감지
+- vterm 버퍼 스캔으로 CWD 폴백 감지
 
 ### 3. 파일 트리 (tree/mod.rs)
 - `ignore` crate로 gitignore 지원
 - 디렉토리 우선 정렬
-- 선택적 확장/축소
-- 검색 기능
+- 항상 전체 확장 (읽기 전용 패시브 디스플레이)
+- CWD 마커(●) 표시
 
-### 4. 이벤트 루프 (event.rs)
-- tokio 기반 비동기
-- 250ms tick rate
-- 키/마우스/리사이즈 이벤트 통합
+### 4. 이벤트 루프 (event.rs + main.rs)
+- tokio select! 기반 비동기
+- 모든 키 입력을 PTY로 직접 전달
+- 파일 변경 감시 (notify) 통합
+- CWD 변경 시 디바운스된 트리 갱신
 
 ## 테스트 전략
 


### PR DESCRIPTION
## Summary

- Update CLAUDE.md project structure, dependencies, architecture diagram, and feature descriptions to match v0.2.0
- Add `.claude/` to `.gitignore` to prevent local Claude Code config from being committed

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` — all 71 tests pass
- [x] No sensitive content in committed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)