### PR TITLE
chore: 미사용 코드 및 의존성 제거

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,56 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
-name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "3.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
-dependencies = [
- "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -192,51 +142,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "clap"
-version = "4.5.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
-dependencies = [
- "clap_builder",
- "clap_derive",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
-dependencies = [
- "anstream",
- "anstyle",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.5.55"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
-
-[[package]]
 name = "claude-explorer"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "clap",
  "crossterm",
  "dirs",
  "futures",
@@ -246,18 +155,10 @@ dependencies = [
  "portable-pty",
  "ratatui",
  "tempfile",
- "thiserror 2.0.18",
  "tokio",
  "unicode-width",
  "vte",
- "walkdir",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
@@ -795,12 +696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is_terminal_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
 name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1092,12 +987,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "option-ext"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ notify-debouncer-mini = "0.7"
 
 # File tree handling
 ignore = "0.4"              # gitignore support
-walkdir = "2.5"
 
 # PTY for terminal embedding
 portable-pty = "0.9"
@@ -32,9 +31,7 @@ portable-pty = "0.9"
 # Utilities
 futures = "0.3"
 anyhow = "1.0"
-thiserror = "2.0"
 dirs = "5.0"
-clap = { version = "4.5", features = ["derive"] }
 unicode-width = "0.2"
 vte = "0.15"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,8 +10,6 @@ pub struct App {
     pub tree: FileTree,
     pub terminal: TerminalPane,
     pub tree_width_percent: u16,
-    #[allow(dead_code)]
-    pub should_quit: bool,
     pub tree_loading: bool,
 }
 
@@ -30,7 +28,6 @@ impl App {
             tree: FileTree::new(&canonical_path, show_hidden, max_depth)?,
             terminal: TerminalPane::new(&canonical_path, &claude_args, pty_tx)?,
             tree_width_percent: tree_width.clamp(10, 50),
-            should_quit: false,
             tree_loading: true,
         })
     }
@@ -69,14 +66,10 @@ impl App {
         }
     }
 
-    pub fn handle_resize(&mut self, _width: u16, _height: u16) {
-        // Handle terminal resize if needed
-    }
-
     pub fn handle_file_change(&mut self, path: PathBuf) {
         // Refresh tree if file changed
         if path.starts_with(self.tree.root_path()) {
-            self.tree.refresh_path(&path);
+            self.tree.refresh();
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -206,9 +206,7 @@ async fn run_app(
             event::Event::Mouse(mouse_event) => {
                 app.handle_mouse(mouse_event);
             }
-            event::Event::Resize(width, height) => {
-                app.handle_resize(width, height);
-            }
+            event::Event::Resize(_width, _height) => {}
             event::Event::FileChange(path) => {
                 app.handle_file_change(path);
             }

--- a/src/tree/file_node.rs
+++ b/src/tree/file_node.rs
@@ -18,15 +18,6 @@ impl FileNode {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn icon(&self) -> &'static str {
-        if self.is_dir {
-            "▸ "
-        } else {
-            "· "
-        }
-    }
-
     pub fn expanded_icon(&self, expanded: bool) -> &'static str {
         if self.is_dir {
             if expanded {
@@ -93,25 +84,5 @@ impl FileNode {
             // Default
             _ => Color::Rgb(180, 180, 180),
         }
-    }
-
-    #[allow(dead_code)]
-    pub fn tree_prefix(&self, is_last: bool) -> String {
-        if self.depth == 0 {
-            return String::new();
-        }
-
-        let mut prefix = String::new();
-        for _ in 0..self.depth.saturating_sub(1) {
-            prefix.push_str("│   ");
-        }
-
-        if is_last {
-            prefix.push_str("└── ");
-        } else {
-            prefix.push_str("├── ");
-        }
-
-        prefix
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -45,10 +45,6 @@ impl FileTree {
         self.offset = offset;
     }
 
-    pub fn is_expanded(&self, _path: &Path) -> bool {
-        true
-    }
-
     fn rebuild_visible_nodes(&mut self) -> Result<()> {
         self.nodes.clear();
         self.build_tree(&self.root.clone(), 0)?;
@@ -112,11 +108,5 @@ impl FileTree {
 
     pub fn refresh(&mut self) {
         let _ = self.rebuild_visible_nodes();
-    }
-
-    pub fn refresh_path(&mut self, _path: &Path) {
-        // For now, just do a full refresh
-        // Could be optimized to only refresh the affected subtree
-        self.refresh();
     }
 }

--- a/src/ui/file_tree_widget.rs
+++ b/src/ui/file_tree_widget.rs
@@ -41,7 +41,7 @@ impl<'a> StatefulWidget for FileTreeWidget<'a> {
 
             // Build the line
             let indent = "  ".repeat(node.depth);
-            let icon = node.expanded_icon(self.tree.is_expanded(&node.path));
+            let icon = node.expanded_icon(true);
 
             // Check if this node is the CWD
             let is_cwd = self.cwd.is_some_and(|cwd| node.is_dir && node.path == cwd);


### PR DESCRIPTION
## Summary
- Cargo.toml에서 미사용 의존성 3개 제거 (`walkdir`, `thiserror`, `clap`)
- `file_node.rs`에서 `#[allow(dead_code)]` 메서드 2개 제거 (`icon`, `tree_prefix`)
- `app.rs`에서 미사용 `should_quit` 필드 및 빈 `handle_resize` 스텁 제거
- `tree/mod.rs`에서 스텁 메서드 2개 제거 (`is_expanded`, `refresh_path`) 및 호출처 인라인 대체

## Test plan
- [x] `cargo fmt` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo test` 전체 71개 테스트 통과
- [x] pre-push hook 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)