### PR TITLE
chore: rename claude-explorer to cltree

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug to help us improve Claude Explorer
+description: Report a bug to help us improve cltree
 title: "[Bug]: "
 labels: ["bug", "triage"]
 body:
@@ -14,11 +14,11 @@ body:
       label: Prerequisites
       description: Please confirm the following before submitting
       options:
-        - label: I have searched the [existing issues](https://github.com/jsleemaster/claude-explorer/issues) and this bug has not been reported
+        - label: I have searched the [existing issues](https://github.com/jsleemaster/cltree/issues) and this bug has not been reported
           required: true
-        - label: I am using the latest version of Claude Explorer
+        - label: I am using the latest version of cltree
           required: true
-        - label: I have read the [README](https://github.com/jsleemaster/claude-explorer#readme)
+        - label: I have read the [README](https://github.com/jsleemaster/cltree#readme)
           required: true
 
   - type: textarea
@@ -36,7 +36,7 @@ body:
       label: Steps to Reproduce
       description: Steps to reproduce the behavior
       placeholder: |
-        1. Run `claude-explorer --path /some/dir`
+        1. Run `cltree --path /some/dir`
         2. Press '...'
         3. Navigate to '...'
         4. See error
@@ -70,7 +70,7 @@ body:
         - OS: [e.g., macOS 14.0, Ubuntu 22.04, Windows 11]
         - Terminal: [e.g., iTerm2, Terminal.app, Windows Terminal]
         - Shell: [e.g., zsh, bash, fish]
-        - Claude Explorer version: [run `claude-explorer --version`]
+        - cltree version: [run `cltree --version`]
         - Rust version (if building from source): [run `rustc --version`]
     validations:
       required: true
@@ -81,7 +81,7 @@ body:
       label: Diagnostic Output
       description: |
         If applicable, please include any error messages or diagnostic output.
-        You can run with `RUST_LOG=debug claude-explorer 2> debug.log` to capture debug logs.
+        You can run with `RUST_LOG=debug cltree 2> debug.log` to capture debug logs.
       placeholder: Paste any error messages or logs here...
       render: shell
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/jsleemaster/claude-explorer#readme
+    url: https://github.com/jsleemaster/cltree#readme
     about: Check out the README for usage instructions and examples
   - name: Discussions
-    url: https://github.com/jsleemaster/claude-explorer/discussions
+    url: https://github.com/jsleemaster/cltree/discussions
     about: Ask questions and discuss features with the community

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature Request
-description: Suggest a new feature or enhancement for Claude Explorer
+description: Suggest a new feature or enhancement for cltree
 title: "[Feature]: "
 labels: ["enhancement", "triage"]
 body:
@@ -14,9 +14,9 @@ body:
       label: Prerequisites
       description: Please confirm the following before submitting
       options:
-        - label: I have searched the [existing issues](https://github.com/jsleemaster/claude-explorer/issues) and this feature has not been requested
+        - label: I have searched the [existing issues](https://github.com/jsleemaster/cltree/issues) and this feature has not been requested
           required: true
-        - label: I have read the [README](https://github.com/jsleemaster/claude-explorer#readme) and confirmed this feature doesn't already exist
+        - label: I have read the [README](https://github.com/jsleemaster/cltree#readme) and confirmed this feature doesn't already exist
           required: true
 
   - type: dropdown

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@
 
 ## Checklist
 
-- [ ] I have read the [CONTRIBUTING](https://github.com/jsleemaster/claude-explorer/blob/main/CONTRIBUTING.md) guide
+- [ ] I have read the [CONTRIBUTING](https://github.com/jsleemaster/cltree/blob/main/CONTRIBUTING.md) guide
 - [ ] `cargo fmt` passed
 - [ ] `cargo clippy -- -D warnings` passed
 - [ ] `cargo test` passed

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,24 +16,24 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            artifact_name: claude-explorer
-            asset_name: claude-explorer-linux-x86_64
+            artifact_name: cltree
+            asset_name: cltree-linux-x86_64
           - os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-            artifact_name: claude-explorer
-            asset_name: claude-explorer-linux-aarch64
+            artifact_name: cltree
+            asset_name: cltree-linux-aarch64
           - os: macos-latest
             target: x86_64-apple-darwin
-            artifact_name: claude-explorer
-            asset_name: claude-explorer-macos-x86_64
+            artifact_name: cltree
+            asset_name: cltree-macos-x86_64
           - os: macos-latest
             target: aarch64-apple-darwin
-            artifact_name: claude-explorer
-            asset_name: claude-explorer-macos-aarch64
+            artifact_name: cltree
+            asset_name: cltree-macos-aarch64
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            artifact_name: claude-explorer.exe
-            asset_name: claude-explorer-windows-x86_64.exe
+            artifact_name: cltree.exe
+            asset_name: cltree-windows-x86_64.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -74,9 +74,9 @@ jobs:
       - name: Create tarball (Unix)
         if: runner.os != 'Windows'
         run: |
-          cp ${{ matrix.asset_name }} claude-explorer
-          tar czf ${{ matrix.asset_name }}.tar.gz claude-explorer
-          rm claude-explorer
+          cp ${{ matrix.asset_name }} cltree
+          tar czf ${{ matrix.asset_name }}.tar.gz cltree
+          rm cltree
 
       - name: Upload tarball
         if: runner.os != 'Windows'
@@ -189,10 +189,10 @@ jobs:
       - name: Compute SHA256 checksums
         id: sha
         run: |
-          echo "MACOS_AARCH64=$(sha256sum artifacts/claude-explorer-macos-aarch64.tar.gz/claude-explorer-macos-aarch64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
-          echo "MACOS_X86_64=$(sha256sum artifacts/claude-explorer-macos-x86_64.tar.gz/claude-explorer-macos-x86_64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
-          echo "LINUX_X86_64=$(sha256sum artifacts/claude-explorer-linux-x86_64.tar.gz/claude-explorer-linux-x86_64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
-          echo "LINUX_AARCH64=$(sha256sum artifacts/claude-explorer-linux-aarch64.tar.gz/claude-explorer-linux-aarch64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "MACOS_AARCH64=$(sha256sum artifacts/cltree-macos-aarch64.tar.gz/cltree-macos-aarch64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "MACOS_X86_64=$(sha256sum artifacts/cltree-macos-x86_64.tar.gz/cltree-macos-x86_64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "LINUX_X86_64=$(sha256sum artifacts/cltree-linux-x86_64.tar.gz/cltree-linux-x86_64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          echo "LINUX_AARCH64=$(sha256sum artifacts/cltree-linux-aarch64.tar.gz/cltree-linux-aarch64.tar.gz | cut -d' ' -f1)" >> $GITHUB_OUTPUT
 
       - name: Checkout homebrew-tap
         uses: actions/checkout@v6
@@ -204,43 +204,43 @@ jobs:
       - name: Update formula
         run: |
           VERSION="${{ steps.version.outputs.VERSION }}"
-          RELEASE_URL="https://github.com/jsleemaster/claude-explorer/releases/download/v${VERSION}"
+          RELEASE_URL="https://github.com/jsleemaster/cltree/releases/download/v${VERSION}"
           SHA_MACOS_AARCH64="${{ steps.sha.outputs.MACOS_AARCH64 }}"
           SHA_MACOS_X86_64="${{ steps.sha.outputs.MACOS_X86_64 }}"
           SHA_LINUX_X86_64="${{ steps.sha.outputs.LINUX_X86_64 }}"
           SHA_LINUX_AARCH64="${{ steps.sha.outputs.LINUX_AARCH64 }}"
-          cat > homebrew-tap/Formula/claude-explorer.rb <<EOF
-          class ClaudeExplorer < Formula
+          cat > homebrew-tap/Formula/cltree.rb <<EOF
+          class Cltree < Formula
             desc "A TUI file explorer for Claude Code CLI"
-            homepage "https://github.com/jsleemaster/claude-explorer"
+            homepage "https://github.com/jsleemaster/cltree"
             license "MIT"
 
             on_macos do
               if Hardware::CPU.arm?
-                url "${RELEASE_URL}/claude-explorer-macos-aarch64.tar.gz"
+                url "${RELEASE_URL}/cltree-macos-aarch64.tar.gz"
                 sha256 "${SHA_MACOS_AARCH64}"
               else
-                url "${RELEASE_URL}/claude-explorer-macos-x86_64.tar.gz"
+                url "${RELEASE_URL}/cltree-macos-x86_64.tar.gz"
                 sha256 "${SHA_MACOS_X86_64}"
               end
             end
 
             on_linux do
               if Hardware::CPU.arm?
-                url "${RELEASE_URL}/claude-explorer-linux-aarch64.tar.gz"
+                url "${RELEASE_URL}/cltree-linux-aarch64.tar.gz"
                 sha256 "${SHA_LINUX_AARCH64}"
               else
-                url "${RELEASE_URL}/claude-explorer-linux-x86_64.tar.gz"
+                url "${RELEASE_URL}/cltree-linux-x86_64.tar.gz"
                 sha256 "${SHA_LINUX_X86_64}"
               end
             end
 
             def install
-              bin.install "claude-explorer"
+              bin.install "cltree"
             end
 
             test do
-              assert_match "claude-explorer", shell_output("\#{bin}/claude-explorer --version")
+              assert_match "cltree", shell_output("\#{bin}/cltree --version")
             end
           end
           EOF
@@ -250,6 +250,6 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/claude-explorer.rb
-          git commit -m "Update claude-explorer to v${{ steps.version.outputs.VERSION }}"
+          git add Formula/cltree.rb
+          git commit -m "Update cltree to v${{ steps.version.outputs.VERSION }}"
           git push

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ Thumbs.db
 .claude/
 
 # npm package - downloaded binaries
-npm/bin/claude-explorer
-npm/bin/claude-explorer.exe
+npm/bin/cltree
+npm/bin/cltree.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Command line options for path, tree width, hidden files, and depth
 - Help popup with `?` or `F1`
 
-[Unreleased]: https://github.com/jsleemaster/claude-explorer/compare/v0.2.0...HEAD
-[0.2.0]: https://github.com/jsleemaster/claude-explorer/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/jsleemaster/claude-explorer/releases/tag/v0.1.0
+[Unreleased]: https://github.com/jsleemaster/cltree/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/jsleemaster/cltree/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/jsleemaster/cltree/releases/tag/v0.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,11 @@
-# Claude Explorer - Project Context
+# cltree - Project Context
 
 Claude Code CLI 옆에 파일 트리를 보여주는 TUI 앱. Rust + ratatui 기반.
 
 ## 프로젝트 구조
 
 ```
-claude-explorer/
+cltree/
 ├── src/
 │   ├── main.rs              # 진입점, 터미널 초기화, 이벤트 루프
 │   ├── app.rs               # App 상태, 키 입력 핸들링
@@ -141,7 +141,7 @@ cargo test ui::
 - [ ] PTY 리사이즈 동기화 개선
 - [ ] 파일 변경 감지 (notify) 통합
 - [ ] 마우스 클릭으로 파일 선택
-- [ ] 설정 파일 지원 (~/.config/claude-explorer/config.toml)
+- [ ] 설정 파일 지원 (~/.config/cltree/config.toml)
 - [ ] 테마 커스터마이징
 
 ## 디버깅 팁

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-[GitHub Issues](https://github.com/jsleemaster/claude-explorer/issues).
+[GitHub Issues](https://github.com/jsleemaster/cltree/issues).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Claude Explorer
+# Contributing to cltree
 
-Thank you for your interest in contributing to Claude Explorer! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to cltree! This document provides guidelines and instructions for contributing.
 
 ## Language Policy
 
@@ -18,12 +18,12 @@ Thank you for your interest in contributing to Claude Explorer! This document pr
 1. Fork the repository on GitHub
 2. Clone your fork locally:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/claude-explorer.git
-   cd claude-explorer
+   git clone https://github.com/YOUR_USERNAME/cltree.git
+   cd cltree
    ```
 3. Add the upstream repository as a remote:
    ```bash
-   git remote add upstream https://github.com/jsleemaster/claude-explorer.git
+   git remote add upstream https://github.com/jsleemaster/cltree.git
    ```
 
 ## Build Commands
@@ -129,7 +129,7 @@ Be respectful and inclusive. We welcome contributors from all backgrounds and ex
 ## Questions?
 
 If you have questions, feel free to:
-- Open a [Discussion](https://github.com/jsleemaster/claude-explorer/discussions)
+- Open a [Discussion](https://github.com/jsleemaster/cltree/discussions)
 - Ask in your PR or issue
 
 Thank you for contributing!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,8 +142,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "claude-explorer"
-version = "0.2.0"
+name = "cltree"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "claude-explorer"
+name = "cltree"
 version = "0.2.1"
 edition = "2021"
 authors = ["jsleemaster"]
 description = "A TUI file explorer for Claude Code CLI"
 license = "MIT"
-repository = "https://github.com/jsleemaster/claude-explorer"
-homepage = "https://github.com/jsleemaster/claude-explorer"
+repository = "https://github.com/jsleemaster/cltree"
+homepage = "https://github.com/jsleemaster/cltree"
 keywords = ["cli", "tui", "file-explorer", "claude", "terminal"]
 categories = ["command-line-utilities", "development-tools"]
 

--- a/DEVELOPMENT_PLAN.md
+++ b/DEVELOPMENT_PLAN.md
@@ -1,10 +1,10 @@
-# Claude Explorer - 개발 계획서
+# cltree - 개발 계획서
 
 ## 📋 개요
 
 | 항목 | 내용 |
 |------|------|
-| 프로젝트명 | claude-explorer |
+| 프로젝트명 | cltree |
 | 목표 | Claude Code CLI 옆에 파일 트리 UI를 보여주는 TUI 앱 |
 | 언어 | Rust |
 | 프레임워크 | ratatui + crossterm |
@@ -16,8 +16,8 @@
 
 ### 1.1 프로젝트 생성
 ```bash
-cargo new claude-explorer
-cd claude-explorer
+cargo new cltree
+cd cltree
 ```
 
 ### 1.2 Cargo.toml 의존성 추가
@@ -205,7 +205,7 @@ touch src/tree/mod.rs src/tree/file_node.rs
 ```
 
 ### 6.2 완료 기준
-- [ ] `claude-explorer --help` 출력
+- [ ] `cltree --help` 출력
 - [ ] 다양한 옵션 조합 테스트
 
 ---
@@ -281,7 +281,7 @@ touch src/tree/mod.rs src/tree/file_node.rs
 ### 시작하기
 ```bash
 # 프로젝트 디렉토리로 이동
-cd claude-explorer
+cd cltree
 
 # Claude Code 실행
 claude

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# 🦀 Claude Explorer
+# cltree
 
-[![GitHub Release](https://img.shields.io/github/v/release/jsleemaster/claude-explorer)](https://github.com/jsleemaster/claude-explorer/releases)
-[![npm](https://img.shields.io/npm/v/claude-explorer)](https://www.npmjs.com/package/claude-explorer)
-[![Crates.io Version](https://img.shields.io/crates/v/claude-explorer)](https://crates.io/crates/claude-explorer)
-[![Crates.io Downloads](https://img.shields.io/crates/d/claude-explorer)](https://crates.io/crates/claude-explorer)
+[![GitHub Release](https://img.shields.io/github/v/release/jsleemaster/cltree)](https://github.com/jsleemaster/cltree/releases)
+[![npm](https://img.shields.io/npm/v/cltree)](https://www.npmjs.com/package/cltree)
+[![Crates.io Version](https://img.shields.io/crates/v/cltree)](https://crates.io/crates/cltree)
+[![Crates.io Downloads](https://img.shields.io/crates/d/cltree)](https://crates.io/crates/cltree)
 [![Homebrew](https://img.shields.io/badge/homebrew-available-blue)](https://github.com/jsleemaster/homebrew-tap)
-[![GitHub Stars](https://img.shields.io/github/stars/jsleemaster/claude-explorer)](https://github.com/jsleemaster/claude-explorer/stargazers)
-[![GitHub Issues](https://img.shields.io/github/issues/jsleemaster/claude-explorer)](https://github.com/jsleemaster/claude-explorer/issues)
+[![GitHub Stars](https://img.shields.io/github/stars/jsleemaster/cltree)](https://github.com/jsleemaster/cltree/stargazers)
+[![GitHub Issues](https://img.shields.io/github/issues/jsleemaster/cltree)](https://github.com/jsleemaster/cltree/issues)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 A terminal-based file explorer designed to work alongside Claude Code CLI. View your project structure in a split-pane TUI while using Claude Code.
@@ -26,7 +26,7 @@ A terminal-based file explorer designed to work alongside Claude Code CLI. View 
 └─────────────────────────────────────────────┴──────────────────────┘
 ```
 
-## ✨ Features
+## Features
 
 - **Split-pane TUI**: File tree on the right, Claude Code on the left
 - **Passive file tree**: Always-expanded, read-only project structure display
@@ -36,53 +36,53 @@ A terminal-based file explorer designed to work alongside Claude Code CLI. View 
 - **File icons**: Visual indicators for different file types
 - **Zero interference**: All keystrokes are forwarded directly to Claude Code
 
-## 📦 Installation
+## Installation
 
 ### npm / bun
 
 ```bash
-npm install -g claude-explorer
+npm install -g cltree
 # or
-bun install -g claude-explorer
+bun install -g cltree
 ```
 
 ### Homebrew (macOS / Linux)
 
 ```bash
-brew install jsleemaster/tap/claude-explorer
+brew install jsleemaster/tap/cltree
 ```
 
 ### From crates.io
 
 ```bash
-cargo install claude-explorer
+cargo install cltree
 ```
 
 ### From source
 
 ```bash
-git clone https://github.com/jsleemaster/claude-explorer.git
-cd claude-explorer
+git clone https://github.com/jsleemaster/cltree.git
+cd cltree
 cargo install --path .
 ```
 
-## 🚀 Usage
+## Usage
 
 ```bash
 # Start in current directory
-claude-explorer
+cltree
 
 # Start in specific directory
-claude-explorer --path /path/to/project
+cltree --path /path/to/project
 
 # Adjust tree width (10-50%)
-claude-explorer --tree-width 25
+cltree --tree-width 25
 
 # Show hidden files
-claude-explorer --show-hidden
+cltree --show-hidden
 ```
 
-## ⌨️ Keyboard Shortcuts
+## Keyboard Shortcuts
 
 | Key | Action |
 |-----|--------|
@@ -90,7 +90,7 @@ claude-explorer --show-hidden
 
 All other keystrokes are passed directly to Claude Code.
 
-## 🔧 Configuration
+## Configuration
 
 ### Command line options
 
@@ -104,12 +104,12 @@ Options:
   -V, --version              Print version
 ```
 
-## 🛠️ Development
+## Development
 
 ```bash
 # Clone
-git clone https://github.com/jsleemaster/claude-explorer.git
-cd claude-explorer
+git clone https://github.com/jsleemaster/cltree.git
+cd cltree
 
 # Run in development
 cargo run
@@ -121,13 +121,13 @@ cargo test
 cargo build --release
 ```
 
-## 📋 Requirements
+## Requirements
 
 - Rust 1.70+
 - Claude Code CLI installed and in PATH
 - Terminal with UTF-8 and true color support
 
-## 🤝 Contributing
+## Contributing
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
@@ -137,11 +137,11 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 
-## 📄 License
+## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## 🙏 Acknowledgments
+## Acknowledgments
 
 - [ratatui](https://github.com/ratatui-org/ratatui) - Terminal UI framework
 - [Claude Code](https://claude.com) - AI coding assistant by Anthropic

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 
 2. **Email**: Send a detailed report to the maintainer via GitHub private message or create a private security advisory.
 
-3. **GitHub Security Advisory**: You can also report vulnerabilities through [GitHub's Security Advisory feature](https://github.com/jsleemaster/claude-explorer/security/advisories/new).
+3. **GitHub Security Advisory**: You can also report vulnerabilities through [GitHub's Security Advisory feature](https://github.com/jsleemaster/cltree/security/advisories/new).
 
 ### What to Include
 
@@ -46,7 +46,7 @@ Please include the following information in your report:
 
 This security policy applies to:
 
-- The `claude-explorer` binary and its source code
+- The `cltree` binary and its source code
 - Dependencies used by the project
 
 ### Out of Scope
@@ -59,6 +59,6 @@ This security policy applies to:
 - Always download releases from official sources (GitHub releases or crates.io)
 - Verify checksums when available
 - Keep your installation up to date
-- Be cautious when running Claude Explorer in directories with untrusted content
+- Be cautious when running cltree in directories with untrusted content
 
-Thank you for helping keep Claude Explorer secure!
+Thank you for helping keep cltree secure!

--- a/npm/.npmignore
+++ b/npm/.npmignore
@@ -1,3 +1,3 @@
 # Downloaded binaries (should not be published)
-bin/claude-explorer
-bin/claude-explorer.exe
+bin/cltree
+bin/cltree.exe

--- a/npm/README.md
+++ b/npm/README.md
@@ -1,34 +1,34 @@
-# claude-explorer
+# cltree
 
 A terminal-based file explorer designed to work alongside Claude Code CLI. View your project structure in a split-pane TUI while using Claude Code.
 
 ## Installation
 
 ```bash
-npm install -g claude-explorer
+npm install -g cltree
 # or
-bun install -g claude-explorer
+bun install -g cltree
 ```
 
 ## Usage
 
 ```bash
 # Start in current directory
-claude-explorer
+cltree
 
 # Start in specific directory
-claude-explorer --path /path/to/project
+cltree --path /path/to/project
 
 # Adjust tree width (10-50%)
-claude-explorer --tree-width 25
+cltree --tree-width 25
 
 # Show hidden files
-claude-explorer --show-hidden
+cltree --show-hidden
 ```
 
 ## How it works
 
-This package downloads the pre-built native binary for your platform from [GitHub Releases](https://github.com/jsleemaster/claude-explorer/releases) during installation. No Rust toolchain required.
+This package downloads the pre-built native binary for your platform from [GitHub Releases](https://github.com/jsleemaster/cltree/releases) during installation. No Rust toolchain required.
 
 ### Supported platforms
 
@@ -40,12 +40,12 @@ This package downloads the pre-built native binary for your platform from [GitHu
 
 ```bash
 # From crates.io
-cargo install claude-explorer
+cargo install cltree
 
 # Homebrew (macOS/Linux)
-brew install jsleemaster/tap/claude-explorer
+brew install jsleemaster/tap/cltree
 ```
 
 ## License
 
-MIT - see [LICENSE](https://github.com/jsleemaster/claude-explorer/blob/main/LICENSE)
+MIT - see [LICENSE](https://github.com/jsleemaster/cltree/blob/main/LICENSE)

--- a/npm/bin/cli.js
+++ b/npm/bin/cli.js
@@ -13,7 +13,7 @@ try {
   if (err.status !== null) {
     process.exit(err.status);
   }
-  console.error(`Failed to run claude-explorer: ${err.message}`);
+  console.error(`Failed to run cltree: ${err.message}`);
   console.error(`Binary path: ${binaryPath}`);
   process.exit(1);
 }

--- a/npm/install.js
+++ b/npm/install.js
@@ -8,8 +8,8 @@ const { getBinaryPath, getDownloadUrl, getPlatformKey } = require("./lib/platfor
 const MAX_REDIRECTS = 5;
 
 function main() {
-  if (process.env.CLAUDE_EXPLORER_SKIP_INSTALL) {
-    console.log("Skipping binary download (CLAUDE_EXPLORER_SKIP_INSTALL is set)");
+  if (process.env.CLTREE_SKIP_INSTALL) {
+    console.log("Skipping binary download (CLTREE_SKIP_INSTALL is set)");
     return;
   }
 
@@ -21,7 +21,7 @@ function main() {
   // Ensure bin directory exists
   fs.mkdirSync(path.dirname(dest), { recursive: true });
 
-  console.log(`Downloading claude-explorer v${version} for ${getPlatformKey()}...`);
+  console.log(`Downloading cltree v${version} for ${getPlatformKey()}...`);
   console.log(`  ${url}`);
 
   download(url, dest, 0)
@@ -30,13 +30,13 @@ function main() {
       if (process.platform !== "win32") {
         fs.chmodSync(dest, 0o755);
       }
-      console.log("claude-explorer installed successfully!");
+      console.log("cltree installed successfully!");
     })
     .catch((err) => {
-      console.error(`\nFailed to download claude-explorer: ${err.message}\n`);
+      console.error(`\nFailed to download cltree: ${err.message}\n`);
       console.error("You can install manually:");
-      console.error(`  cargo install claude-explorer`);
-      console.error(`  Or download from: https://github.com/jsleemaster/claude-explorer/releases`);
+      console.error(`  cargo install cltree`);
+      console.error(`  Or download from: https://github.com/jsleemaster/cltree/releases`);
       process.exit(1);
     });
 }
@@ -52,7 +52,7 @@ function download(url, dest, redirectCount) {
     const options = {
       hostname: parsedUrl.hostname,
       path: parsedUrl.pathname + parsedUrl.search,
-      headers: { "User-Agent": "claude-explorer-npm-installer" },
+      headers: { "User-Agent": "cltree-npm-installer" },
     };
 
     https

--- a/npm/lib/platform.js
+++ b/npm/lib/platform.js
@@ -4,11 +4,11 @@ const os = require("os");
 const path = require("path");
 
 const PLATFORM_MAP = {
-  "darwin-arm64": "claude-explorer-macos-aarch64",
-  "darwin-x64": "claude-explorer-macos-x86_64",
-  "linux-x64": "claude-explorer-linux-x86_64",
-  "linux-arm64": "claude-explorer-linux-aarch64",
-  "win32-x64": "claude-explorer-windows-x86_64.exe",
+  "darwin-arm64": "cltree-macos-aarch64",
+  "darwin-x64": "cltree-macos-x86_64",
+  "linux-x64": "cltree-linux-x86_64",
+  "linux-arm64": "cltree-linux-aarch64",
+  "win32-x64": "cltree-windows-x86_64.exe",
 };
 
 function getPlatformKey() {
@@ -28,7 +28,7 @@ function getAssetName() {
 }
 
 function getBinaryName() {
-  return os.platform() === "win32" ? "claude-explorer.exe" : "claude-explorer";
+  return os.platform() === "win32" ? "cltree.exe" : "cltree";
 }
 
 function getBinaryPath() {
@@ -37,7 +37,7 @@ function getBinaryPath() {
 
 function getDownloadUrl(version) {
   const asset = getAssetName();
-  return `https://github.com/jsleemaster/claude-explorer/releases/download/v${version}/${asset}`;
+  return `https://github.com/jsleemaster/cltree/releases/download/v${version}/${asset}`;
 }
 
 module.exports = { getAssetName, getBinaryName, getBinaryPath, getDownloadUrl, getPlatformKey };

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "claude-explorer",
+  "name": "cltree",
   "version": "0.0.0",
   "description": "A TUI file explorer for Claude Code CLI",
   "bin": {
-    "claude-explorer": "bin/cli.js"
+    "cltree": "bin/cli.js"
   },
   "scripts": {
     "postinstall": "node install.js"
@@ -20,11 +20,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/jsleemaster/claude-explorer.git"
+    "url": "https://github.com/jsleemaster/cltree.git"
   },
-  "homepage": "https://github.com/jsleemaster/claude-explorer",
+  "homepage": "https://github.com/jsleemaster/cltree",
   "bugs": {
-    "url": "https://github.com/jsleemaster/claude-explorer/issues"
+    "url": "https://github.com/jsleemaster/cltree/issues"
   },
   "os": [
     "darwin",

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ struct Args {
     claude_args: Vec<String>,
 }
 
-/// claude-explorer 자체 플래그만 꺼내고, 나머지는 모두 Claude Code CLI로 전달
+/// cltree 자체 플래그만 꺼내고, 나머지는 모두 Claude Code CLI로 전달
 fn parse_args() -> Args {
     let raw: Vec<String> = std::env::args().skip(1).collect();
 
@@ -51,7 +51,7 @@ fn parse_args() -> Args {
         if arg == "-h" || arg == "--help" {
             eprintln!(
                 "A TUI file explorer for Claude Code CLI\n\n\
-                 Usage: claude-explorer [OPTIONS] [CLAUDE_ARGS...]\n\n\
+                 Usage: cltree [OPTIONS] [CLAUDE_ARGS...]\n\n\
                  Options:\n\
                  \x20 -p, --path <PATH>         Working directory [default: .]\n\
                  \x20 -w, --tree-width <WIDTH>   Tree panel width %% (10-50) [default: 30]\n\
@@ -60,13 +60,13 @@ fn parse_args() -> Args {
                  \x20 -h, --help                 Print help\n\
                  \x20 -V, --version              Print version\n\n\
                  All other arguments are passed through to Claude Code CLI.\n\
-                 Example: claude-explorer --resume\n\
-                 Example: claude-explorer -p /my/project --continue"
+                 Example: cltree --resume\n\
+                 Example: cltree -p /my/project --continue"
             );
             std::process::exit(0);
         }
         if arg == "-V" || arg == "--version" {
-            eprintln!("claude-explorer {}", env!("CARGO_PKG_VERSION"));
+            eprintln!("cltree {}", env!("CARGO_PKG_VERSION"));
             std::process::exit(0);
         }
 

--- a/tests/vterm_test.rs
+++ b/tests/vterm_test.rs
@@ -1,4 +1,4 @@
-use claude_explorer::vterm::VirtualTerminal;
+use cltree::vterm::VirtualTerminal;
 use ratatui::prelude::*;
 
 #[test]


### PR DESCRIPTION
## Summary
- Rename project from `claude-explorer` to `cltree` to remove "Claude" trademark from package name
- Updated all 23 files: Cargo.toml, npm package, CI workflows, issue templates, and documentation
- All tests pass (71/71), build verified

## Changes
- `claude-explorer` → `cltree` (hyphenated)
- `claude_explorer` → `cltree` (underscore/crate name)
- `Claude Explorer` → `cltree` (display name)
- `CLAUDE_EXPLORER_SKIP_INSTALL` → `CLTREE_SKIP_INSTALL` (env var)
- All GitHub URLs updated to `jsleemaster/cltree`
- Homebrew formula class renamed to `Cltree`

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — 71 tests pass
- [x] `cargo run -- --help` shows "cltree"
- [x] `grep -r "claude-explorer"` — zero remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)