### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cltree"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cltree"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["jsleemaster"]
 description = "A TUI file explorer for Claude Code CLI"


### PR DESCRIPTION
## Summary
- Bump version to 0.2.2 for first release as `cltree`

## Test plan
- [x] `cargo build` succeeds
- [x] `cargo test` — 71 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)