### PR TITLE
docs: README를 일반 유저 대상으로 정리

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,20 @@ cargo clippy -- -D warnings
 cargo run
 ```
 
+## Alternative Installation (for Rust developers)
+
+If you have Rust installed, you can install cltree directly:
+
+```bash
+# From crates.io
+cargo install cltree
+
+# From source
+git clone https://github.com/jsleemaster/cltree.git
+cd cltree
+cargo install --path .
+```
+
 ## Code Conventions
 
 - **Edition**: Rust 2021

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![GitHub Release](https://img.shields.io/github/v/release/jsleemaster/cltree)](https://github.com/jsleemaster/cltree/releases)
 [![npm](https://img.shields.io/npm/v/cltree)](https://www.npmjs.com/package/cltree)
-[![Crates.io Version](https://img.shields.io/crates/v/cltree)](https://crates.io/crates/cltree)
 [![Homebrew](https://img.shields.io/badge/homebrew-available-blue)](https://github.com/jsleemaster/homebrew-tap)
 [![GitHub Stars](https://img.shields.io/github/stars/jsleemaster/cltree)](https://github.com/jsleemaster/cltree/stargazers)
 [![GitHub Issues](https://img.shields.io/github/issues/jsleemaster/cltree)](https://github.com/jsleemaster/cltree/issues)
@@ -51,20 +50,6 @@ bun install -g cltree
 brew install jsleemaster/tap/cltree
 ```
 
-### From crates.io
-
-```bash
-cargo install cltree
-```
-
-### From source
-
-```bash
-git clone https://github.com/jsleemaster/cltree.git
-cd cltree
-cargo install --path .
-```
-
 ## Usage
 
 ```bash
@@ -103,38 +88,9 @@ Options:
   -V, --version              Print version
 ```
 
-## Development
-
-```bash
-# Clone
-git clone https://github.com/jsleemaster/cltree.git
-cd cltree
-
-# Run in development
-cargo run
-
-# Run tests
-cargo test
-
-# Build release
-cargo build --release
-```
-
-## Requirements
-
-- Rust 1.70+
-- Claude Code CLI installed and in PATH
-- Terminal with UTF-8 and true color support
-
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
 
 ## License
 


### PR DESCRIPTION
## Summary
- README에서 Rust 개발자 전용 설치 방법(cargo install, From source), Development, Requirements 섹션 제거
- Crates.io 배지 제거
- Contributing 섹션을 CONTRIBUTING.md 링크로 간결화
- CONTRIBUTING.md에 Alternative Installation (for Rust developers) 섹션 추가

## Test plan
- [ ] README에 `cargo install`, `cargo run`, `cargo build`, `Rust 1.70` 등이 없는지 확인
- [ ] CONTRIBUTING.md에 cargo install 방법이 있는지 확인
- [ ] README 링크가 정상 작동하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)